### PR TITLE
Removed explicit dependency on multi_json since it doesn't appear to be ...

### DIFF
--- a/fullcontact.gemspec
+++ b/fullcontact.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'hashie', '~> 1.2.0'
   s.add_runtime_dependency 'faraday', '~> 0.8'
   s.add_runtime_dependency 'faraday_middleware', '~> 0.8.6'
-  s.add_runtime_dependency 'multi_json', '~> 1.2.0'
   s.add_runtime_dependency 'multi_xml', '~> 0.4.2'
   s.add_runtime_dependency 'rash', '~> 0.3.0'
 


### PR DESCRIPTION
...used anywhere.

I need to use the latest version (or at least newer than 1.2.x) of multi_json in my project as well as the fullcontact gem. I couldn't find any code in the fullcontact project that explicitly used the MultiJson module, so I thought it would be safe to remove it from the gemspec.

Thanks!
