### PR TITLE
Updated gemspec for multi-xml to work with Mailchimp's multi-xml

### DIFF
--- a/fullcontact.gemspec
+++ b/fullcontact.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'hashie', '~> 1.2.0'
   s.add_runtime_dependency 'faraday', '~> 0.8'
   s.add_runtime_dependency 'faraday_middleware', '~> 0.8.6'
-  s.add_runtime_dependency 'multi_xml', '~> 0.4.2'
+  s.add_runtime_dependency 'multi_xml', '>= 0.4.2'
   s.add_runtime_dependency 'rash', '~> 0.3.0'
 
   s.author = "FullContact, Inc."

--- a/lib/fullcontact/version.rb
+++ b/lib/fullcontact/version.rb
@@ -1,3 +1,3 @@
 module FullContact
-	VERSION = "0.4.1"
+	VERSION = "0.4.2"
 end


### PR DESCRIPTION
The locked version of multi-xml wasn't compatible with Mailchimp's dependency on multi-xml.  Changed the gemspec to require >= 0.4.2 rather than ~> 0.4.2.

API continues to work as expected, and co-exists nicely with the Mailchimp gem.
