### PR TITLE
Updating gem dependency of faraday_middleware

### DIFF
--- a/fullcontact.gemspec
+++ b/fullcontact.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard', '~> 0.7'
   s.add_runtime_dependency 'hashie', '~> 1.2.0'
   s.add_runtime_dependency 'faraday', '~> 0.8'
-  s.add_runtime_dependency 'faraday_middleware', '~> 0.8.6'
+  s.add_runtime_dependency 'faraday_middleware', '~> 0.9'
   s.add_runtime_dependency 'multi_xml', '>= 0.4.2'
   s.add_runtime_dependency 'rash', '~> 0.3.0'
 


### PR DESCRIPTION
To make work with the latest version of Faraday, and Faraday Middlewave
