### PR TITLE
Support header based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ But you can also turn it into a normal hash
     person.to_hash['contact_info']['family_name']
      => "Lorang"
 ```
+Authentication is done through query parameters by default. If you want to use headers instead:
+
+```ruby
+    # This could go in an initializer
+    FullContact.configure do |config|
+        config.api_key = 'fullcontact_api_key_goes_here'
+        config.authentication_method = :headers # :header or :query
+    end
+```
 
 There's other ways you can query the Person API:
 ```ruby

--- a/lib/fullcontact/configuration.rb
+++ b/lib/fullcontact/configuration.rb
@@ -8,6 +8,7 @@ module FullContact
     VALID_OPTIONS_KEYS = [
         :adapter,
         :api_key,
+        :auth_type,
         :endpoint,
         :format,
         :skip_rubyize,
@@ -26,6 +27,9 @@ module FullContact
 
     # By default, don't set an application key
     DEFAULT_API_KEY = nil
+
+    # By default, use query parameters
+    DEFAULT_AUTH_TYPE = :query
 
     # The endpoint that will be used to connect if none is set
     #
@@ -49,6 +53,8 @@ module FullContact
     DEFAULT_USER_AGENT = "FullContact Ruby Client/#{FullContact::VERSION}".freeze
 
     DEFAULT_GATEWAY = nil
+
+    AUTH_HEADER_NAME = 'X-FullContact-APIKey'.freeze
 
     # @private
     attr_accessor *VALID_OPTIONS_KEYS
@@ -74,6 +80,7 @@ module FullContact
     def reset
       self.adapter = DEFAULT_ADAPTER
       self.api_key = DEFAULT_API_KEY
+      self.auth_type = DEFAULT_AUTH_TYPE
       self.endpoint = DEFAULT_ENDPOINT
       self.format = DEFAULT_FORMAT
       self.skip_rubyize = DEFAULT_SKIP_RUBYIZE

--- a/lib/fullcontact/request.rb
+++ b/lib/fullcontact/request.rb
@@ -10,10 +10,16 @@ module FullContact
 
     # Perform an HTTP request
     def request(method, path, options, raw=false, faraday_options={})
-      options[:apiKey] = FullContact.options[:api_key]
+      if FullContact.options[:auth_type] == :query
+        options[:apiKey] = FullContact.options[:api_key]
+      end
 
       response = connection(raw, faraday_options).send(method) do |request|
         request.url(formatted_path(path), options)
+
+        if FullContact.options[:auth_type] == :header
+          request.headers[FullContact::Configuration::AUTH_HEADER_NAME] = FullContact.options[:api_key]
+        end
       end
 
       raw ? response : response.body

--- a/spec/ruby_fullcontact/api_spec.rb
+++ b/spec/ruby_fullcontact/api_spec.rb
@@ -30,6 +30,7 @@ describe FullContact::API do
       before do
         @configuration = {
             :api_key => 'api_key',
+            :auth_type => :headers,
             :adapter => :typhoeus,
             :endpoint => 'http://tumblr.com/',
             :gateway => 'apigee-1111.apigee.com',


### PR DESCRIPTION
As per the [docs][1], FullContact supports two modes of authentication:

1. Query param
2. Request Header

This library however only supports sending auth through query param. This PR adds support for sending the auth through request header.  

Default behaviour remains unchanged. Request headers are opt-in, through configuration. I've updated the docs to reflect this option.


[1]: https://www.fullcontact.com/developer/docs/ 
