### PR TITLE
Support Rails 5 by removing plissken dependency

### DIFF
--- a/fullcontact.gemspec
+++ b/fullcontact.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'hashie', ['>= 2.0', '< 4.0']
   s.add_runtime_dependency 'faraday', '~> 0.9.0'
   s.add_runtime_dependency 'faraday_middleware', '>= 0.9'
-  s.add_runtime_dependency 'plissken'
 
   s.author = 'FullContact, Inc.'
   s.description = %q{A Ruby wrapper for the FullContact API}

--- a/lib/faraday/response/rubyize.rb
+++ b/lib/faraday/response/rubyize.rb
@@ -1,5 +1,3 @@
-require 'plissken'
-
 module Faraday
   class Response::Rubyize < Response::Middleware
     def parse(body)

--- a/lib/fullcontact.rb
+++ b/lib/fullcontact.rb
@@ -1,5 +1,6 @@
 require 'faraday'
 require 'faraday_middleware'
+require 'fullcontact/ext/hash/to_snake_keys'
 require 'fullcontact/error'
 require 'fullcontact/configuration'
 require 'fullcontact/api'

--- a/lib/fullcontact/ext/hash/to_snake_keys.rb
+++ b/lib/fullcontact/ext/hash/to_snake_keys.rb
@@ -1,0 +1,41 @@
+# Hash.to_snake_keys
+class Hash
+  # Recursively converts CamelCase and camelBack JSON-style hash keys to
+  # Rubyish snake_case, suitable for use during instantiation of Ruby
+  # model attributes.
+  #
+  def to_snake_keys(value = self)
+    case value
+    when Array
+      value.map { |v| to_snake_keys(v) }
+    when Hash
+      snake_hash(value)
+    else
+      value
+    end
+  end
+
+  private
+
+  def snake_hash(value)
+    Hash[value.map { |k, v| [underscore_key(k).to_sym, to_snake_keys(v)] }]
+  end
+
+  def underscore_key(k)
+    if k.is_a? Symbol
+      underscore(k.to_s).to_sym
+    elsif k.is_a? String
+      underscore(k)
+    else
+      k # Plissken can't snakify anything except strings and symbols
+    end
+  end
+
+  def underscore(string)
+    string.gsub(/::/, '/')
+      .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+      .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+      .tr('-', '_')
+      .downcase
+  end
+end


### PR DESCRIPTION
plissken required ActiveSupport ~> 3.2 where Rails 5 requires 5.0. Bundler fails to resolve as both can't be installed simultaneously.