### PR TITLE
Updated faraday gem version per customer request

### DIFF
--- a/fullcontact.gemspec
+++ b/fullcontact.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock', '~> 1.6'
   s.add_development_dependency 'yard', '~> 0.9.11'
   s.add_runtime_dependency 'hashie', ['>= 2.0', '< 4.0']
-  s.add_runtime_dependency 'faraday', '~> 0.11.0'
+  s.add_runtime_dependency 'faraday', '~> 0.14.0'
   s.add_runtime_dependency 'faraday_middleware', '>= 0.10'
 
   s.author = 'FullContact, Inc.'


### PR DESCRIPTION
@fullcontact/data Pinging you as a courtesy here based on this customer ticket. `bundle exec rake test` runs just fine with the Faraday (just an HTTP client lib) version updated. 