### PR TITLE
Fix 403 Error for default requests without any auth type

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A Ruby wrapper for the [FullContact API](http://www.fullcontact.com/)
 
 Changes
 -------
+- 0.18.1
+  - Always use the token in header even when the option is given as query.
 - 0.18.0
     - Add ability to query Company API by company name
     - Fix XML bug in Company API module

--- a/lib/fullcontact/request.rb
+++ b/lib/fullcontact/request.rb
@@ -10,16 +10,9 @@ module FullContact
 
     # Perform an HTTP request
     def request(method, path, options, raw=false, faraday_options={})
-      if FullContact.options[:auth_type] == :query
-        options[:apiKey] = FullContact.options[:api_key]
-      end
-
       response = connection(raw, faraday_options).send(method) do |request|
         request.url(formatted_path(path), options)
-
-        if FullContact.options[:auth_type] == :header
-          request.headers[FullContact::Configuration::AUTH_HEADER_NAME] = FullContact.options[:api_key]
-        end
+        request.headers[FullContact::Configuration::AUTH_HEADER_NAME] = FullContact.options[:api_key]
       end
 
       raw ? response : response.body

--- a/lib/fullcontact/request.rb
+++ b/lib/fullcontact/request.rb
@@ -11,6 +11,9 @@ module FullContact
     # Perform an HTTP request
     def request(method, path, options, raw=false, faraday_options={})
       response = connection(raw, faraday_options).send(method) do |request|
+        if FullContact.options[:auth_type] == :query
+          options[:apiKey] = FullContact.options[:api_key]
+        end
         request.url(formatted_path(path), options)
         request.headers[FullContact::Configuration::AUTH_HEADER_NAME] = FullContact.options[:api_key]
       end

--- a/lib/fullcontact/version.rb
+++ b/lib/fullcontact/version.rb
@@ -1,3 +1,3 @@
 module FullContact
-  VERSION = '0.18.0'
+  VERSION = '0.18.1'
 end


### PR DESCRIPTION
Basically removing query type of auth type and include api key in request headers all the time

[ch72652]